### PR TITLE
feat(data): add Pintilie Tamoxifen dataset

### DIFF
--- a/README.md
+++ b/README.md
@@ -398,11 +398,22 @@ df = pd.DataFrame(
 
 - [Pintilie Tamoxifen](https://onlinelibrary.wiley.com/doi/book/10.1002/9780470870709)
   - Accompanied the linked text, but is now unavailable, so it is included in the [datasets directory](https://github.com/andrewtavis/causeinfer/blob/main/src/causeinfer/data/datasets) for direct download
-  - Needed [(see issue)](https://github.com/andrewtavis/causeinfer/issues/19):
-    - Formatting script
-    - Example notebook
-    - Tests
-    - Documentation
+  - Is formatted with causeinfer (see [causeinfer.data.tamoxifen](https://github.com/andrewtavis/causeinfer/blob/main/src/causeinfer/data/tamoxifen.py))
+  - An example notebook is planned as a follow-up (see issue #19); see the Python usage below
+
+```python
+from causeinfer.data import tamoxifen
+
+data_tamoxifen = tamoxifen.load_tamoxifen(
+    file_path="src/causeinfer/data/datasets/tamoxifen.txt",
+    format_covariates=True,
+    normalize=True,
+)
+
+df = pd.DataFrame(
+    data_tamoxifen["dataset_full"], columns=data_tamoxifen["dataset_full_names"]
+)
+```
 
 </p>
 </details>
@@ -637,6 +648,7 @@ Please see the [contribution guidelines](https://github.com/andrewtavis/causeinf
 - Banerjee, A., Duflo, E., Glennerster, R., and Kinnan, C (2015). "The Miracle of Microfinance? Evidence from a Randomized Evaluation." American Economic Journal: Applied Economics, 7 (1), pp. 22-53. URL: https://www.aeaweb.org/articles?id=10.1257/app.20130533.
 - K. Hillstrom. “The MineThatData E-Mail Analytics And Data Mining Challenge”. 2008. URL: https://blog.minethatdata.com/2008/03/minethatdata-e-mail-analytics-and-data.html.
 - Mayo Clinic. “Primary Biliary Cirrhosis”. 1991. URL: https://www.mayo.edu/research/documents/pbchtml/DOC-10027635.
+- Pintilie, M. "Competing Risks: A Practical Perspective". Wiley, 2006. URL: https://onlinelibrary.wiley.com/doi/book/10.1002/9780470870709.
 
 </p>
 </details>

--- a/docs/source/data/index.rst
+++ b/docs/source/data/index.rst
@@ -14,6 +14,7 @@ Data in causeinfer provides examples for business, medical, and socio-economic f
    :caption: Medical:
 
    mayo_pbc
+   tamoxifen
 
 .. toctree::
    :maxdepth: 2

--- a/docs/source/data/tamoxifen.rst
+++ b/docs/source/data/tamoxifen.rst
@@ -1,0 +1,3 @@
+.. automodule:: causeinfer.data.tamoxifen
+   :members:
+   :private-members:

--- a/src/causeinfer/data/tamoxifen.py
+++ b/src/causeinfer/data/tamoxifen.py
@@ -1,8 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
 """
-Pintilie Tamoxifen
-------------------
-
 A dataset on competing risks from a breast cancer trial of tamoxifen versus control.
 
 An example notebook is planned (see issue #19).
@@ -40,15 +37,15 @@ def download_tamoxifen(data_path=None, url=""):
 
     Parameters
     ----------
-        data_path : str : optional (default=None)
-            A user specified path for where the data should go.
+    data_path : str : optional (default=None)
+        A user specified path for where the data should go.
 
-        url : str
-            The url from which the data is to be downloaded.
+    url : str
+        The url from which the data is to be downloaded.
 
     Returns
     -------
-        None
+    None
         This function is deprecated and raises NotImplementedError. The dataset is
         bundled in 'src/causeinfer/data/datasets/tamoxifen.txt'.
     """
@@ -61,26 +58,26 @@ def download_tamoxifen(data_path=None, url=""):
 
 def _format_data(df, format_covariates=True, normalize=True):
     """
-    Formats the data upon loading for consistent data preparation.
+    Format the data upon loading for consistent data preparation.
 
     Parameters
     ----------
-        df : pd.DataFrame
-            The original unformatted version of the data as read from the bundled
-            'tamoxifen.txt' file.
+    df : pd.DataFrame
+        The original unformatted version of the data as read from the bundled
+        'tamoxifen.txt' file.
 
-        format_covariates : bool : optional (default=True), controlled in load_tamoxifen
-            - True: creates dummy columns and encodes the data.
+    format_covariates : bool : optional (default=True), controlled in load_tamoxifen
+        - True: creates dummy columns and encodes the data.
 
-            - False: only steps for data readability will be taken.
+        - False: only steps for data readability will be taken.
 
-        normalize : bool : optional (default=True), controlled in load_tamoxifen
-            Normalize dataset columns to prepare them for ML methods.
+    normalize : bool : optional (default=True), controlled in load_tamoxifen
+        Normalize dataset columns to prepare them for ML methods.
 
     Returns
     -------
-        df : pd.DataFrame
-            A formated version of the data.
+    pd.DataFrame
+        A formatted version of the data.
     """
     # Drop non-feature columns: the patient id, the survival time (its event
     # indicator is 'stat' and would leak the response), and the competing-risks
@@ -139,58 +136,59 @@ def load_tamoxifen(
     normalize=True,
 ):
     """
-    Loads the Pintilie Tamoxifen dataset with formatting if desired.
+    Load the Pintilie Tamoxifen dataset with formatting if desired.
 
     Parameters
     ----------
-        file_path : str : optional (default=None)
-            Specify another path for the dataset.
+    file_path : str : optional (default=None)
+        Specify another path for the dataset.
 
-            When None, the bundled dataset at
-            src/causeinfer/data/datasets/tamoxifen.txt is used.
+        When None, the bundled dataset at
+        src/causeinfer/data/datasets/tamoxifen.txt is used.
 
-        format_covariates : bool : optional (default=True)
-            Indicates whether raw data should be loaded without covariate manipulation.
+    format_covariates : bool : optional (default=True)
+        Indicates whether raw data should be loaded without covariate manipulation.
 
-        download_if_missing : bool : optional (default=True)
-            If True and the dataset is missing, attempt download via
-            'download_tamoxifen' (deprecated; raises NotImplementedError). The
-            dataset is bundled and is loaded by default from
-            src/causeinfer/data/datasets/tamoxifen.txt.
+    download_if_missing : bool : optional (default=True)
+        If True and the dataset is missing, attempt download via
+        'download_tamoxifen' (deprecated; raises NotImplementedError). The
+        dataset is bundled and is loaded by default from
+        src/causeinfer/data/datasets/tamoxifen.txt.
 
-        normalize : bool : optional (default=True)
-            Normalize the dataset to prepare it for ML methods.
+    normalize : bool : optional (default=True)
+        Normalize the dataset to prepare it for ML methods.
 
     Returns
     -------
-        data : dict object with the following attributes:
+    dict
+        Object with the following attributes:
 
-            data.description : str
-                A description of the Pintilie Tamoxifen dataset.
+        data.description : str
+            A description of the Pintilie Tamoxifen dataset.
 
-            data.dataset_full : numpy.ndarray : (641, 8) or formatted (641, 15)
-                The full dataset with features, treatment, and target variables.
+        data.dataset_full : numpy.ndarray : (641, 8) or formatted (641, 15)
+            The full dataset with features, treatment, and target variables.
 
-            data.dataset_full_names : list, size 8 or formatted 15
-                List of dataset variables names.
+        data.dataset_full_names : list, size 8 or formatted 15
+            List of dataset variables names.
 
-            data.features : numpy.ndarray : (641, 6) or formatted (641, 13)
-                Each row corresponding to the 6 feature values in order.
+        data.features : numpy.ndarray : (641, 6) or formatted (641, 13)
+            Each row corresponding to the 6 feature values in order.
 
-            data.feature_names : list, size 6 or formatted 13
-                List of feature names.
+        data.feature_names : list, size 6 or formatted 13
+            List of feature names.
 
-            data.treatment : numpy.ndarray : (641,)
-                Each value corresponds to the treatment (1 = tamoxifen, 0 = control).
+        data.treatment : numpy.ndarray : (641,)
+            Each value corresponds to the treatment (1 = tamoxifen, 0 = control).
 
-            data.response : numpy.ndarray : (641,)
-                Each value corresponds to the overall event indicator (0 = censored, 1 = event).
+        data.response : numpy.ndarray : (641,)
+            Each value corresponds to the overall event indicator (0 = censored, 1 = event).
 
     Notes
     -----
-        `survtime` and the competing-risks time/censor columns are intentionally
-        dropped as post-treatment outcomes to avoid leakage, even though
-        `mayo_pbc` retains its baseline time column (`days_since_register`).
+    `survtime` and the competing-risks time/censor columns are intentionally
+    dropped as post-treatment outcomes to avoid leakage, even though
+    `mayo_pbc` retains its baseline time column (`days_since_register`).
     """
     # Default to the bundled dataset so load_tamoxifen() works out of the box.
     if file_path is None:

--- a/src/causeinfer/data/tamoxifen.py
+++ b/src/causeinfer/data/tamoxifen.py
@@ -1,0 +1,254 @@
+# SPDX-License-Identifier: BSD-3-Clause
+"""
+Pintilie Tamoxifen
+------------------
+
+A dataset on competing risks from a breast cancer trial of tamoxifen versus control.
+
+An example notebook is planned (see issue #19).
+
+Description found at:
+    https://onlinelibrary.wiley.com/doi/book/10.1002/9780470870709
+
+Based on
+    Pintilie, M. "Competing Risks: A Practical Perspective". Wiley, 2006.
+    URL: https://onlinelibrary.wiley.com/doi/book/10.1002/9780470870709.
+
+The original source is no longer available, so the dataset is bundled in
+'src/causeinfer/data/datasets/tamoxifen.txt'.
+
+Contents
+    download_tamoxifen (deprecated),
+    _format_data,
+    load_tamoxifen
+"""
+
+import os
+
+import numpy as np
+import pandas as pd
+
+from causeinfer.data.download_utils import get_download_paths
+
+
+def download_tamoxifen(data_path=None, url=""):
+    """
+    ! download_tamoxifen is deprecated as the dataset is bundled in the repository.
+
+    The original source is no longer available online, so the dataset is distributed
+    directly in 'src/causeinfer/data/datasets/tamoxifen.txt'.
+
+    Parameters
+    ----------
+        data_path : str : optional (default=None)
+            A user specified path for where the data should go.
+
+        url : str
+            The url from which the data is to be downloaded.
+
+    Returns
+    -------
+        None
+        This function is deprecated and raises NotImplementedError. The dataset is
+        bundled in 'src/causeinfer/data/datasets/tamoxifen.txt'.
+    """
+    raise NotImplementedError(
+        "download_tamoxifen is deprecated as the original source is no longer "
+        "available. The dataset is bundled in "
+        "'src/causeinfer/data/datasets/tamoxifen.txt'."
+    )
+
+
+def _format_data(df, format_covariates=True, normalize=True):
+    """
+    Formats the data upon loading for consistent data preparation.
+
+    Parameters
+    ----------
+        df : pd.DataFrame
+            The original unformatted version of the data as read from the bundled
+            'tamoxifen.txt' file.
+
+        format_covariates : bool : optional (default=True), controlled in load_tamoxifen
+            - True: creates dummy columns and encodes the data.
+
+            - False: only steps for data readability will be taken.
+
+        normalize : bool : optional (default=True), controlled in load_tamoxifen
+            Normalize dataset columns to prepare them for ML methods.
+
+    Returns
+    -------
+        df : pd.DataFrame
+            A formated version of the data.
+    """
+    # Drop non-feature columns: the patient id, the survival time (its event
+    # indicator is 'stat' and would leak the response), and the competing-risks
+    # time/censor pairs.
+    drop_cols = [
+        "stnum",
+        "survtime",
+        "loctime",
+        "lcens",
+        "axltime",
+        "acens",
+        "distime",
+        "dcens",
+        "maltime",
+        "mcens",
+    ]
+    df = df.drop(columns=drop_cols)
+
+    # Recode tx into a binary treatment (T=1 tamoxifen, B=0 control).
+    df = df.rename(columns={"tx": "treatment"})
+    df["treatment"] = df["treatment"].map({"T": 1, "B": 0})
+
+    if format_covariates:
+        # Create dummy columns for the categorical baseline covariates.
+        dummy_cols = ["hist", "nodediss", "hrlevel"]
+        for col in dummy_cols:
+            df = pd.get_dummies(df, columns=[col], prefix=col)
+    else:
+        # Label-encode the categorical string columns so the resulting
+        # DataFrame is fully numeric (castable to float), matching the numeric
+        # behavior of mayo_pbc's format_covariates=False path.
+        for col in ["hist", "nodediss", "hrlevel"]:
+            df[col] = df[col].astype("category").cat.codes
+
+    if normalize:
+        normalization_fields = ["pathsize", "hgb", "age"]
+        df[normalization_fields] = (
+            df[normalization_fields] - df[normalization_fields].mean()
+        ) / df[normalization_fields].std()
+
+    # Put treatment and response at the front and end of the df respectively.
+    cols = list(df.columns)
+    cols.insert(0, cols.pop(cols.index("treatment")))
+    cols.append(cols.pop(cols.index("stat")))
+    df = df.loc[:, cols]
+
+    df = df.astype(float)
+
+    return df
+
+
+def load_tamoxifen(
+    file_path=None,
+    format_covariates=True,
+    download_if_missing=True,
+    normalize=True,
+):
+    """
+    Loads the Pintilie Tamoxifen dataset with formatting if desired.
+
+    Parameters
+    ----------
+        file_path : str : optional (default=None)
+            Specify another path for the dataset.
+
+            When None, the bundled dataset at
+            src/causeinfer/data/datasets/tamoxifen.txt is used.
+
+        format_covariates : bool : optional (default=True)
+            Indicates whether raw data should be loaded without covariate manipulation.
+
+        download_if_missing : bool : optional (default=True)
+            If True and the dataset is missing, attempt download via
+            'download_tamoxifen' (deprecated; raises NotImplementedError). The
+            dataset is bundled and is loaded by default from
+            src/causeinfer/data/datasets/tamoxifen.txt.
+
+        normalize : bool : optional (default=True)
+            Normalize the dataset to prepare it for ML methods.
+
+    Returns
+    -------
+        data : dict object with the following attributes:
+
+            data.description : str
+                A description of the Pintilie Tamoxifen dataset.
+
+            data.dataset_full : numpy.ndarray : (641, 8) or formatted (641, 15)
+                The full dataset with features, treatment, and target variables.
+
+            data.dataset_full_names : list, size 8 or formatted 15
+                List of dataset variables names.
+
+            data.features : numpy.ndarray : (641, 6) or formatted (641, 13)
+                Each row corresponding to the 6 feature values in order.
+
+            data.feature_names : list, size 6 or formatted 13
+                List of feature names.
+
+            data.treatment : numpy.ndarray : (641,)
+                Each value corresponds to the treatment (1 = tamoxifen, 0 = control).
+
+            data.response : numpy.ndarray : (641,)
+                Each value corresponds to the overall event indicator (0 = censored, 1 = event).
+
+    Notes
+    -----
+        `survtime` and the competing-risks time/censor columns are intentionally
+        dropped as post-treatment outcomes to avoid leakage, even though
+        `mayo_pbc` retains its baseline time column (`days_since_register`).
+    """
+    # Default to the bundled dataset so load_tamoxifen() works out of the box.
+    if file_path is None:
+        file_path = os.path.join(os.path.dirname(__file__), "datasets", "tamoxifen.txt")
+
+    # Check that the dataset exists.
+    directory_path, dataset_path = get_download_paths(
+        file_path=file_path,
+        file_directory="datasets",
+        file_name="tamoxifen.txt",
+    )
+    # Fill above path if not.
+    if not os.path.exists(dataset_path):
+        if download_if_missing:
+            download_tamoxifen(directory_path)
+        else:
+            raise FileNotFoundError(
+                "The dataset does not exist. The dataset is bundled in "
+                "'src/causeinfer/data/datasets/tamoxifen.txt'."
+            )
+
+    # Read the data.
+    df = pd.read_csv(dataset_path)
+
+    # Load formatted or raw data.
+    if format_covariates:
+        df = (
+            _format_data(df, format_covariates=True, normalize=True)
+            if normalize
+            else _format_data(df, format_covariates=True, normalize=False)
+        )
+
+    elif normalize:
+        df = _format_data(df, format_covariates=False, normalize=True)
+
+    else:
+        df = _format_data(df, format_covariates=False, normalize=False)
+
+    description = (
+        'The Tamoxifen dataset from Pintilie, M. "Competing Risks: A Practical Perspective" (Wiley, 2006) '
+        "comes from a breast cancer clinical trial comparing tamoxifen (treatment) to a control. "
+        "The response 'stat' is the overall event indicator (0 = censored, 1 = event). "
+        "Baseline covariates include pathsize, hist, hgb, nodediss, age, and hrlevel. "
+        "The survival time and competing-risks time/censor columns are dropped to avoid leakage, "
+        "leaving only baseline covariates."
+    )
+
+    # Fields dropped to split the data for the user.
+    drop_fields = ["stat", "treatment"]
+
+    return {
+        "description": description,
+        "dataset_full": df.values,
+        "dataset_full_names": np.array(df.columns),
+        "features": df.drop(drop_fields, axis=1).values,
+        "feature_names": np.array(
+            list(filter(lambda x: x not in drop_fields, df.columns))
+        ),
+        "treatment": df["treatment"].values,
+        "response": df["stat"].values,
+    }

--- a/tests/data/test_tamoxifen.py
+++ b/tests/data/test_tamoxifen.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: BSD-3-Clause
 """
-Tamoxifen Tests
----------------
+Tests for Tamoxifen data.
 """
 
 import os

--- a/tests/data/test_tamoxifen.py
+++ b/tests/data/test_tamoxifen.py
@@ -1,0 +1,31 @@
+# SPDX-License-Identifier: BSD-3-Clause
+"""
+Tamoxifen Tests
+---------------
+"""
+
+import os
+
+from causeinfer.data import tamoxifen
+
+# ! download_tamoxifen is deprecated as the dataset is bundled in the repository
+# def test_download_tamoxifen():
+#     tamoxifen.download_tamoxifen(data_path=None, url="")
+
+
+def test_load_tamoxifen():
+    tamoxifen_data = tamoxifen.load_tamoxifen(
+        file_path="./src/causeinfer/data/datasets/tamoxifen.txt",
+        format_covariates=True,
+        normalize=True,
+    )
+    assert len(tamoxifen_data) == 7
+
+    tamoxifen_data = tamoxifen.load_tamoxifen(
+        file_path="./src/causeinfer/data/datasets/tamoxifen.txt",
+        format_covariates=False,
+        normalize=False,
+    )
+    assert len(tamoxifen_data) == 7
+
+    os.system("rm -rf ./datasets")


### PR DESCRIPTION
## Summary

Addresses #19 (partially). Adds the Pintilie Tamoxifen dataset module, tests, and documentation. The dataset file `src/causeinfer/data/datasets/tamoxifen.txt` is already bundled in the repository (the original Wiley source is unavailable), so this PR wires up the loading/formatting logic, tests, and docs that consume it.

This mirrors the existing `mayo_pbc` module pattern (same domain — medical; also loaded from a bundled text file).

## What's included

- **`src/causeinfer/data/tamoxifen.py`** — `download_tamoxifen` (deprecated; the source is unavailable), `_format_data`, and `load_tamoxifen`. Returns the same 7-key dict shape as `load_mayo_pbc`.
  - Treatment: `tx` recoded to `treatment` (`T` = 1 tamoxifen, `B` = 0 control).
  - Response: `stat` (0 = censored, 1 = event).
  - Baseline covariates kept as features: `pathsize`, `hist`, `hgb`, `nodediss`, `age`, `hrlevel`.
  - `survtime` and the competing-risks time/censor columns (`loctime`/`lcens`, `axltime`/`acens`, `distime`/`dcens`, `maltime`/`mcens`) are intentionally dropped as post-treatment outcomes to avoid leakage. `stnum` (patient id) is also dropped. This is a deliberate deviation from `mayo_pbc`, which retains its baseline time column (`days_since_register`); the difference is documented in the `load_tamoxifen` docstring.
  - `load_tamoxifen()` with default arguments loads the bundled file directly (via `os.path.dirname(__file__)`), so the dataset works out of the box for installed users.
- **`tests/data/test_tamoxifen.py`** — mirrors `test_mayo_pbc.py`; exercises both `format_covariates`/`normalize` branches.
- **`docs/source/data/tamoxifen.rst`** + toctree entry in `docs/source/data/index.rst` (under Medical).
- **`README.md`** — updates the Pintilie Tamoxifen entry from the "Needed" checklist to a usage snippet (matching the Mayo PBC entry), and adds the Pintilie reference to the data references list.

## What's deferred (follow-up)

Issue #19 also asks for:
- `examples/medical_tamoxifen.ipynb` — an example notebook running the valid models over the dataset.
- Adding the dataset to the iterated model comparison notebook (the issue references `examples/an_iterated_model_dataset_comparison.ipynb`, which appears to be a stale path; the current file is `examples/model_iteration.ipynb`).

I've kept this PR intentionally small and focused on the module + tests + docs so it's easy to review. I'd be happy to open a follow-up PR for the notebook(s) — and would appreciate your guidance on the intended target path for the iterated-comparison update.

## Verification

- `uv run pytest tests/data/test_tamoxifen.py -v` → passes.
- `uv run pytest tests/data/ -v` → 5 passed (cmf_micro, hillstrom ×2, mayo_pbc, tamoxifen); no new breakage.
- `uv run ruff format --check` / `uv run ruff check` / `uv run ty check` on the new module → all clean.
- SPDX `BSD-3-Clause` header present on both new `.py` files.
- Smoke-tested all four `format_covariates` × `normalize` combinations: 641 rows, `treatment` sum = 321 (matches `tx == T`), `response` sum = 48 (matches `stat == 1`), no NaNs, normalization correctly scoped to continuous baseline covariates only.

## Notes on CI

`main` currently has pre-existing failures in `ci_pytest` (`tests/test_standard_pred_proba.py`, dependency drift) and `ci_static_analysis` (`ty` diagnostics in `two_model.py`, and `numpydoc` warnings that `mayo_pbc.py` triggers identically). None of these are introduced by this PR — the new module passes every check that passes on `main`, and overall coverage remains well above the 50% gate. The `ci_spdx_license_header_check` job stays green.

Happy to adjust anything (naming, formatting choices, the `survtime` drop rationale, etc.) based on your preferences. Thanks for the great project!